### PR TITLE
DaisyUI theme fix

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,4 +12,7 @@ export default {
     },
   },
   plugins: [require('daisyui')],
+  daisyui: {
+    themes: [],
+  },
 };


### PR DESCRIPTION
This P.R closes #61 and includes:
- A fix where the system was overriding our app theme.
- Now daisyui components should remain the same no matter the system's theme.